### PR TITLE
Update Feed.php

### DIFF
--- a/app/code/community/Doofinder/Feed/Model/Observers/Feed.php
+++ b/app/code/community/Doofinder/Feed/Model/Observers/Feed.php
@@ -153,8 +153,6 @@ class Doofinder_Feed_Model_Observers_Feed
             return;
         }
 
-        $scheduleId = $process->getScheduleId();
-
         // Get store code
         $this->storeCode = $process->getStoreCode();
 
@@ -167,13 +165,6 @@ class Doofinder_Feed_Model_Observers_Feed
         try {
             // Clear out the message
             $process->setMessage($helper::MSG_EMPTY);
-
-            // Get data model for store cron
-            $dataModel = Mage::getModel('cron/schedule');
-
-
-            // Get store cron data
-            $data = $dataModel->load($scheduleId);
 
             // Get current offset
             $offset = intval($process->getOffset());


### PR DESCRIPTION
Since v 1.5.7 there is schedule_id field no longer exist, so  no need to fetch it an load core schedule model.
in other words - use -1 select during feed generation.