### PR TITLE
Use a double slash in values to prevent the doofinder from treating i…

### DIFF
--- a/app/code/community/Doofinder/Feed/Model/Map/Product/Abstract.php
+++ b/app/code/community/Doofinder/Feed/Model/Map/Product/Abstract.php
@@ -465,6 +465,8 @@ class Doofinder_Feed_Model_Map_Product_Abstract extends Varien_Object
         $field = strip_tags($field);
         $field = preg_replace('/[ ]{2,}/', ' ', $field);
         $field = trim($field);
+        // Use a double slash to prevent the doofinder from treating it as a separator
+        $field = str_replace('/', '//', $field);
         // @codingStandardsIgnoreStart
         $field = html_entity_decode($field, null, 'UTF-8');
         // @codingStandardsIgnoreEnd


### PR DESCRIPTION
…t as a separator

refs #60161

Change-Id: I386c466644a65f265e8162191246479a8bd765f6